### PR TITLE
Add gulp to azure deployment script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -117,6 +117,12 @@ if [ -e "$DEPLOYMENT_TARGET/package.json" ]; then
   cd - > /dev/null
 fi
 
+# 4. Test
+pushd %DEPLOYMENT_TARGET%
+call :ExecuteCmd !NPM_CMD! install --development
+call :ExecuteCmd "%NODE_EXE%" node_modules\gulp\bin\gulp
+IF !ERRORLEVEL! NEQ 0 goto error
+popd
 
 ##################################################################################################################################
 

--- a/test/test.js
+++ b/test/test.js
@@ -13,7 +13,8 @@ var options ={
 
 describe("test for tests", function(){ //mock test, to test gulp and deployment
   it("tests should run", function(){
-    var a = 2;  
+    var a = 2;
+    console.log("testing");  
     expect(a).to.equal(2);
   });
 });


### PR DESCRIPTION
When continuously deploying from github, Azure should run the gulp default task (Mocha test).
