### PR TITLE
More attempts to connect coverage tests with CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+general:
+  artifacts:
+    - "coverage/lcove-report" # relative to the build directory

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,14 +35,13 @@ gulp.task('style', function() {
 
 
 gulp.task('testCoverage', function (cb) {
-  var coverageOutput = $CIRCLE_ARTIFACTS || 'coverage';
   gulp.src(['./*.js'])
     .pipe(istanbul({includeUntested: true})) // Covering files; includeUntested is needed to include all files, and not only 'required' ones
     .pipe(istanbul.hookRequire()) // Force `require` to return covered files
     .on('finish', function () {
       gulp.src(['test/test.js'])
         .pipe(mocha({reporter: 'spec'}))
-        .pipe(istanbul.writeReports({dir: coverageOutput})) // Creating the reports after tests ran
+        .pipe(istanbul.writeReports()) // Creating the reports after tests ran
         .on('end', cb);
     });
 });


### PR DESCRIPTION
Added circle.yml file. In this file I indicate which folder contains build artifacts (coverage test results in our case).
